### PR TITLE
Updated Readme file to specify the version of framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ presented on <https://soldernerd.com>.
 
 ## Build dependencies
 
-The project uses Microchip's [MPLAB Harmony Framework](http://www.microchip.com/mplab/mplab-harmony)
+The project uses Microchip's [MPLAB Harmony Framework](Version 1.x) (http://www.microchip.com/mplab/mplab-harmony/mplab-harmony-1-0)
 and requires the [MPLAB X IDE](http://www.microchip.com/mplab/mplab-x-ide) and
 the [MPLAB XC32 Compiler](http://www.microchip.com/mplab/compilers) to be
 installed.


### PR DESCRIPTION
This project will not work with the newest version of MPLAB's Harmony Framework (V2.x). This project works only with MPLAB's Harmony Framework VERSION 1.X
I think it is a good idea to have this on the git repository, so that future users will not have problems using this project. 